### PR TITLE
feat: add renderer package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "pnpm -F @ansi-tools/parser build && pnpm type-check && pnpm test",
+    "prebuild": "pnpm -r build && pnpm type-check && pnpm test",
     "test": "node --test",
     "build": "vite build",
     "postbuild": "node --import isum/no-css scripts/build.ts",

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -1,0 +1,28 @@
+# @ansi-tools/renderer
+
+Renders strings containing ANSI codes (i.e. terminal output) into a "rendered"
+representation, containing each visual frame which would have been displayed.
+
+## Installation
+
+```bash
+npm install @ansi-tools/renderer
+```
+
+## Usage
+
+```ts
+import { renderString } from "@ansi-tools/renderer";
+
+const input = "\x1b[31mHello\x1b[0m World";
+const rendered = renderString(input);
+
+for (const frame of rendered) {
+  // will render frame 1 which is "Hello World"
+  console.log(frame);
+}
+```
+
+## License
+
+ISC

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@ansi-tools/renderer",
+  "version": "1.0.7",
+  "description": "Renders strings containing ANSI escape codes to various outputs.",
+  "main": "./dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./escaped": {
+      "types": "./dist/escaped.d.ts",
+      "import": "./dist/escaped.js",
+      "default": "./dist/escaped.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "pnpm type-check && pnpm test",
+    "build": "tsdown --dts src/index.ts",
+    "dev": "tsdown --dts src/index.ts --watch",
+    "test": "node --test",
+    "type-check": "tsc",
+    "prepack": "pnpm build"
+  },
+  "keywords": [
+    "ansi",
+    "term",
+    "terminal",
+    "ink"
+  ],
+  "author": "ANSI tools maintainers (https://github.com/webpro/ANSI.tools)",
+  "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/webpro/ANSI.tools/tree/main/packages/renderer",
+  "bugs": "https://github.com/webpro/ANSI.tools/issues",
+  "repository": {
+    "type": "git",
+    "url": "github:webpro/ANSI.tools",
+    "directory": "packages/renderer"
+  },
+  "dependencies": {
+    "@ansi-tools/parser": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.13",
+    "tsdown": "^0.12.9",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/renderer/src/commands.ts
+++ b/packages/renderer/src/commands.ts
@@ -1,0 +1,34 @@
+import {
+  type CODE,
+  type CONTROL_CODE,
+} from '@ansi-tools/parser';
+
+export const isCursorCommand = (code: CODE): code is CONTROL_CODE => {
+  return (
+    (
+    code.type === 'CSI' &&
+    (code.command === 'H' ||
+      code.command === 'A' ||
+      code.command === 'B' ||
+      code.command === 'C' ||
+      code.command === 'D' ||
+      code.command === 'E' ||
+      code.command === 'F' ||
+      code.command === 'G' ||
+      code.command === 'T' ||
+      code.command === 'S')) ||
+    (code.type === 'ESC' &&
+      (code.command === '8' || code.command === '7')) ||
+    (code.type === 'DEC' &&
+      (code.command === 'l' || code.command === 'h'))
+  );
+};
+
+export const isEraseCommand = (code: CODE): code is CONTROL_CODE => {
+  return (
+    (code.type === 'CSI' &&
+    (code.command === 'J' || code.command === 'K')) ||
+    (code.type === 'ESC' &&
+     code.command === 'c')
+  );
+};

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1,0 +1,12 @@
+import {Renderer} from "./renderer.ts";
+import {RenderStream} from "./render-stream.ts";
+
+export async function renderString(input: string): Promise<Renderer> {
+  return Renderer.fromString(input);;
+}
+
+export function createRenderStream(): RenderStream {
+  return new RenderStream();
+}
+
+export { Renderer };

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -5,8 +5,4 @@ export async function renderString(input: string): Promise<Renderer> {
   return Renderer.fromString(input);;
 }
 
-export function createRenderStream(): RenderStream {
-  return new RenderStream();
-}
-
-export { Renderer };
+export { Renderer, RenderStream };

--- a/packages/renderer/src/render-stream.ts
+++ b/packages/renderer/src/render-stream.ts
@@ -1,0 +1,41 @@
+import {Writable, WritableOptions} from "node:stream";
+import {Renderer} from "./renderer.ts";
+import {parse} from "@ansi-tools/parser";
+
+export class RenderStream extends Writable {
+  public get isRenderStream(): boolean {
+    return true;
+  }
+
+  public get renderer(): Renderer {
+    return this.#renderer;
+  }
+
+  #buffer: string[] = [];
+  #renderer: Renderer = new Renderer();
+
+  constructor(opts?: WritableOptions) {
+    super(opts);
+
+    this.on('end', () => {
+      this.#updateRenderer();
+    });
+  }
+
+  _write(
+    chunk: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null | undefined) => void
+  ): void {
+    this.#buffer.push(String(chunk));
+    callback();
+  }
+
+  #updateRenderer(): void {
+    const ast = parse(this.#buffer.join(''));
+
+    for (const code of ast) {
+      this.#renderer.write(code);
+    }
+  }
+}

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -1,0 +1,258 @@
+import {CODE, CONTROL_CODE, parse} from "@ansi-tools/parser";
+import {isCursorCommand, isEraseCommand} from "./commands.ts";
+
+export class Renderer {
+  #buffer: string[] = [];
+  #cursorX: number = 0;
+  #cursorY: number = 0;
+  #frames: string[] = [];
+  #savedCursor?: [number, number];
+  #frameWritesEnabled: boolean = true;
+
+  static fromString(input: string): Renderer {
+    const ast = parse(input);
+    const renderer = new Renderer();
+
+    for (const code of ast) {
+      renderer.write(code);
+    }
+
+    return renderer;
+  }
+
+  get frames(): string[] {
+    return [
+      ...this.#frames,
+      this.#buffer.join('\n')
+    ];
+  }
+
+  get cursor(): [x: number, y: number] {
+    return [this.#cursorX, this.#cursorY];
+  }
+
+  get line(): string {
+    return this.#buffer[this.#cursorY] || '';
+  }
+
+  saveCursor(): void {
+    this.#savedCursor = [this.#cursorX, this.#cursorY];
+  }
+
+  restoreCursor(): void {
+    if (this.#savedCursor) {
+      this.cursorTo(this.#savedCursor[0], this.#savedCursor[1]);
+    }
+  }
+
+  cursorUp(count: number): void {
+    this.#cursorY = Math.max(0, this.#cursorY - count);
+  }
+
+  cursorDown(count: number): void {
+    this.#cursorY = Math.min(this.#buffer.length - 1, this.#cursorY + count);
+  }
+
+  cursorTo(x: number, y: number): void {
+    this.#cursorY = Math.max(0, Math.min(this.#buffer.length - 1, y));
+    this.#cursorX = Math.max(0, Math.min(this.line.length - 1, x));
+  }
+
+  cursorForward(count: number): void {
+    this.#cursorX = Math.min(this.line.length - 1, this.#cursorX + count);
+  }
+
+  cursorBackward(count: number): void {
+    this.#cursorX = Math.max(0, this.#cursorX - count);
+  }
+
+  writeText(text: string): void {
+    const parts = text.split('\n');
+
+    if (parts.length === 0) {
+      return;
+    }
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const bufferIndex = this.#cursorY + i;
+      const isFirst = i === 0;
+      const isLast = i === parts.length - 1;
+      const existingLine = this.#buffer[bufferIndex];
+
+      if (existingLine !== undefined) {
+        if (isFirst) {
+          const prefix = existingLine.slice(0, this.#cursorX + 1);
+          this.#buffer[bufferIndex] = prefix + part;
+          this.cursorForward(part.length);
+        } else if (isLast) {
+          const suffix = existingLine.slice(this.#cursorX);
+          this.#buffer[bufferIndex] = part + suffix;
+          this.cursorTo(part.length, bufferIndex);
+        } else {
+          this.#buffer[bufferIndex] = part;
+          this.cursorTo(0, bufferIndex);
+        }
+      } else {
+        this.#buffer.push(part);
+        this.cursorTo(0, bufferIndex);
+      }
+    }
+  }
+
+  cursorByCommand(code: CONTROL_CODE): void {
+    if (code.type === 'DEC' &&
+      (code.command === 'l' || code.command === 'h')) {
+      // Ignore cursor hide/show
+      return;
+    }
+    if (code.type === 'CSI' && (
+      code.command === 'T' || code.command === 'S')) {
+      // Ignore scroll commands
+      return;
+    }
+    if (code.type === 'ESC') {
+      if (code.command === '8') {
+        this.saveCursor();
+      } else if (code.command === '7') {
+        this.restoreCursor();
+      }
+      return;
+    }
+
+    if (code.command === 'H') {
+      this.cursorTo(
+        code.params[0] ? parseInt(code.params[0]) - 1 : 0,
+        code.params[1] ? parseInt(code.params[1]) - 1 : 0
+      );
+      return;
+    }
+
+    const multiplier = code.params[0] ? parseInt(code.params[0]) : 1;
+
+    switch (code.command) {
+      case 'A':
+        this.cursorUp(multiplier);
+        break;
+      case 'B':
+        this.cursorDown(multiplier);
+        break;
+      case 'C':
+        this.cursorForward(multiplier);
+        break;
+      case 'D':
+        this.cursorBackward(multiplier);
+        break;
+      case 'E':
+        this.cursorTo(0, this.#cursorY + multiplier);
+        break;
+      case 'F':
+        this.cursorTo(0, this.#cursorY - multiplier);
+        break;
+      case 'G':
+        this.cursorTo(multiplier - 1, this.#cursorY);
+        break;
+    }
+  }
+
+  eraseAll(): void {
+    this.#pushFrame();
+    this.#buffer = [];
+    this.cursorTo(0, 0);
+  }
+
+  #pushFrame(): void {
+    if (!this.#frameWritesEnabled) {
+      return;
+    }
+    this.#frames.push(this.#buffer.join('\n'));
+  }
+
+  eraseLine(): void {
+    this.#pushFrame();
+    this.#buffer[this.#cursorY] = '';
+    this.cursorTo(0, this.#cursorY);
+  }
+
+  eraseToEndOfLine(): void {
+    this.#pushFrame();
+    const line = this.#buffer[this.#cursorY];
+
+    if (line === undefined) {
+      return;
+    }
+
+    this.#buffer[this.#cursorY] = line.slice(0, this.#cursorX);
+  }
+
+  eraseToStartOfLine(): void {
+    this.#pushFrame();
+    const line = this.#buffer[this.#cursorY];
+
+    if (line === undefined) {
+      return;
+    }
+
+    this.#buffer[this.#cursorY] = ' '.repeat(this.#cursorX) + line.slice(this.#cursorX);
+  }
+
+  eraseToEnd(): void {
+    this.#pushFrame();
+    this.#frameWritesEnabled = false;
+    this.eraseToEndOfLine();
+    this.#frameWritesEnabled = true;
+    this.#buffer.splice(this.#cursorY + 1);
+  }
+
+  eraseToStart(): void {
+    this.#pushFrame();
+    this.#frameWritesEnabled = false;
+    this.eraseToStartOfLine();
+    this.#frameWritesEnabled = true;
+    this.#buffer.splice(0, this.#cursorY);
+    this.cursorTo(this.#cursorX, 0);
+  }
+
+  eraseByCommand(code: CONTROL_CODE): void {
+    if (code.type === 'ESC' && code.command === 'c') {
+      this.eraseAll();
+      return;
+    }
+    const flag = code.params[0] ? parseInt(code.params[0]) : 0;
+    if (code.command === 'J') {
+      switch (flag) {
+        case 0:
+          this.eraseToEnd();
+          break;
+        case 1:
+          this.eraseToStart();
+          break;
+        case 2:
+          this.eraseAll();
+          break;
+      }
+    } else if (code.command === 'K') {
+      switch (flag) {
+        case 0:
+          this.eraseToEndOfLine();
+          break;
+        case 1:
+          this.eraseToStartOfLine();
+          break;
+        case 2:
+          this.eraseLine();
+          break;
+      }
+    }
+  }
+
+  write(code: CODE): void {
+    if (isCursorCommand(code)) {
+      this.cursorByCommand(code);
+    } else if (isEraseCommand(code)) {
+      this.eraseByCommand(code);
+    } else if (code.type === 'TEXT') {
+      this.writeText(code.raw);
+    }
+  }
+}

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "outDir": "./dist",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext",
+    "types": ["node"]
+  },
+  "include": ["src", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,18 +40,21 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
-  packages/perf:
+  packages/renderer:
     dependencies:
-      kleur:
-        specifier: ^4.1.5
-        version: 4.1.5
-      tinybench:
-        specifier: ^2.9.0
-        version: 2.9.0
+      '@ansi-tools/parser':
+        specifier: workspace:*
+        version: link:../parser
     devDependencies:
       '@types/node':
         specifier: ^24.0.13
         version: 24.0.13
+      tsdown:
+        specifier: ^0.12.9
+        version: 0.12.9(typescript@5.8.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -613,10 +616,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  kleur@4.1.5:
-    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
-    engines: {node: '>=6'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -698,9 +697,6 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
-
-  tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
@@ -1223,8 +1219,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  kleur@4.1.5: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -1333,8 +1327,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-
-  tinybench@2.9.0: {}
 
   tinyexec@1.0.1: {}
 


### PR DESCRIPTION
This adds a renderer package which can be used to parse the "frames" which would've been seen by the user.

For example, if we were to render this (pseudo-ansi):

```
foo
bar<CURSOR.UP(1)><ERASE.LINE>
```

We would have two frames:

```ts
[
  "foo\nbar",
  "   \nbar"
]
```

### DRAFT

until i write all the tests and settle on a public interface, and try it out in the vitest serializer which will use it