### PR TITLE
Use `Iterator` type for `parser` argument

### DIFF
--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -30,7 +30,7 @@ function emit(token: CODE) {
   return token;
 }
 
-export function* parser(tokens: Generator<TOKEN>): Generator<CODE> {
+export function* parser(tokens: Iterator<TOKEN>): Generator<CODE> {
   let current = tokens.next();
 
   while (!current.done) {


### PR DESCRIPTION
Hi! I found a small TypeScript issue.

Currently, `parser` only accepts a `Generator` type, but this restricts usage of results from Iterator instance methods or other types confirming to the `Iterator` protocol.

```ts
const iteratorObject = tokenizer(string).filter(token => token.type === "TEXT");
parser(iteratorObject);

// TS2345: Argument of type IteratorObject<TOKEN, undefined, unknown> is not assignable to parameter of type Generator<TOKEN, any, any>

const array = iteratorObject.toArray();
parser(array);

// TS2345: Argument of type TOKEN[] is not assignable to parameter of type Generator<TOKEN, any, any
```

They do all work out of the box, however! Using the `Iterator` type makes the type reflect the actual functionality. :)

