### PR TITLE
perf: use inline condition for introducers

### DIFF
--- a/packages/parser/src/constants.ts
+++ b/packages/parser/src/constants.ts
@@ -1,19 +1,31 @@
-export const BELL = String.fromCharCode(7);
-export const CAN = String.fromCharCode(24);
-export const SUB = String.fromCharCode(26);
-export const ESC = String.fromCharCode(27);
-export const BACKSLASH = String.fromCharCode(92);
-export const DCS = String.fromCharCode(144);
-export const SOS = String.fromCharCode(152);
-export const CSI = String.fromCharCode(155);
-export const ST = String.fromCharCode(156);
-export const OSC = String.fromCharCode(157);
-export const PM = String.fromCharCode(158);
-export const APC = String.fromCharCode(159);
+export const BELL = 7;
+export const BELL_CODE = String.fromCharCode(BELL);
+export const CAN = 24;
+export const CAN_CODE = String.fromCharCode(CAN);
+export const SUB = 26;
+export const SUB_CODE = String.fromCharCode(SUB);
+export const ESC = 27;
+export const ESC_CODE = String.fromCharCode(ESC);
+export const BACKSLASH = 92;
+export const BACKSLASH_CODE = String.fromCharCode(BACKSLASH);
+export const DCS = 144;
+export const DCS_CODE = String.fromCharCode(DCS);
+export const SOS = 152;
+export const SOS_CODE = String.fromCharCode(SOS);
+export const CSI = 155;
+export const CSI_CODE = String.fromCharCode(CSI);
+export const ST = 156;
+export const ST_CODE = String.fromCharCode(ST);
+export const OSC = 157;
+export const OSC_CODE = String.fromCharCode(OSC);
+export const PM = 158;
+export const PM_CODE = String.fromCharCode(PM);
+export const APC = 159;
+export const APC_CODE = String.fromCharCode(APC);
 
-export const CSI_OPEN = "[";
-export const OSC_OPEN = "]";
-export const DEC_OPEN = "?";
+export const CSI_OPEN = "[".charCodeAt(0);
+export const OSC_OPEN = "]".charCodeAt(0);
+export const DEC_OPEN = "?".charCodeAt(0);
 export const PRIVATE_OPENERS = new Set(["<", "=", ">"]);
 
 export const DCS_OPEN = "P";
@@ -22,7 +34,7 @@ export const SOS_OPEN = "^";
 export const PM_OPEN = "X";
 export const STRING_OPENERS = new Set([DCS_OPEN, APC_OPEN, SOS_OPEN, PM_OPEN]);
 
-export const INTERRUPTERS = new Set([CAN, SUB, ESC, CSI, OSC, DCS, APC, PM, SOS]);
+export const INTERRUPTERS = new Set<number>([CAN, SUB, ESC, CSI, OSC, DCS, APC, PM, SOS]);
 export const C0_INTERRUPTERS = new Set([CAN, SUB]);
 
 export const PARAM_SEPARATOR = /[;:]/;

--- a/packages/parser/src/constants.ts
+++ b/packages/parser/src/constants.ts
@@ -24,7 +24,9 @@ export const APC = 159;
 export const APC_CODE = String.fromCharCode(APC);
 
 export const CSI_OPEN = "[".charCodeAt(0);
+export const CSI_OPEN_CODE = String.fromCharCode(CSI_OPEN);
 export const OSC_OPEN = "]".charCodeAt(0);
+export const OSC_OPEN_CODE = String.fromCharCode(OSC_OPEN);
 export const DEC_OPEN = "?".charCodeAt(0);
 export const PRIVATE_OPENERS = new Set(["<", "=", ">"]);
 

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -1,16 +1,16 @@
 import {
   APC_OPEN,
-  APC,
+  APC_CODE,
   CODE_TYPES,
-  CSI,
+  CSI_CODE,
   DCS_OPEN,
-  DCS,
-  ESC,
-  OSC,
+  DCS_CODE,
+  ESC_CODE,
+  OSC_CODE,
   PM_OPEN,
-  PM,
+  PM_CODE,
   SOS_OPEN,
-  SOS,
+  SOS_CODE,
   TOKEN_TYPES,
 } from "./constants.ts";
 import { parseCSI } from "./parsers/csi.ts";
@@ -66,29 +66,29 @@ export function* parser(tokens: IterableIterator<TOKEN>): IterableIterator<CODE>
       }
 
       switch (introducer.code) {
-        case CSI:
+        case CSI_CODE:
           yield emit(parseCSI(introducer, data, final));
           break;
-        case OSC:
+        case OSC_CODE:
           yield emit(parseOSC(introducer, data, final));
           break;
-        case DCS:
+        case DCS_CODE:
         case DCS_OPEN:
           yield emit(parseDCS(introducer, data, final));
           break;
-        case APC:
+        case APC_CODE:
         case APC_OPEN:
           yield emit(parseAPC(introducer, data, final));
           break;
-        case PM:
+        case PM_CODE:
         case PM_OPEN:
           yield emit(parsePM(introducer, data, final));
           break;
-        case SOS:
+        case SOS_CODE:
         case SOS_OPEN:
           yield emit(parseSOS(introducer, data, final));
           break;
-        case ESC:
+        case ESC_CODE:
           yield emit(parseESC(introducer, data, final));
           break;
       }

--- a/packages/parser/src/tokenize.escaped.ts
+++ b/packages/parser/src/tokenize.escaped.ts
@@ -65,6 +65,7 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
   let i = 0;
   let state: State = "GROUND";
   let currentCode: number | undefined;
+  let backslashIndex = input.indexOf(BACKSLASH_CODE);
 
   function setState(next: State, code?: number) {
     if (debug) console.log(`state ${state} → ${next}`);
@@ -76,7 +77,14 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
     if (state === "GROUND") {
       const textStart = i;
       while (i < l) {
-        const backslashIndex = input.indexOf(BACKSLASH_CODE, i);
+        if (backslashIndex === -1) {
+          i = l;
+          break;
+        }
+
+        if (backslashIndex < i) {
+          backslashIndex = input.indexOf(BACKSLASH_CODE, i);
+        }
 
         if (backslashIndex === -1) {
           i = l;

--- a/packages/parser/src/tokenize.escaped.ts
+++ b/packages/parser/src/tokenize.escaped.ts
@@ -10,6 +10,8 @@ import {
   OSC_CODE,
   OSC_OPEN,
   STRING_OPENERS,
+  CSI_OPEN_CODE,
+  OSC_OPEN_CODE,
   TOKEN_TYPES
 } from "./constants.ts";
 import type { TOKEN } from "./types.ts";
@@ -132,19 +134,18 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
                 setState("SEQUENCE", CSI);
               } else {
                 const next = input[i + len];
-                const nextCode = input.charCodeAt(i + len);
-                if (nextCode === CSI_OPEN) {
+                if (next === CSI_OPEN_CODE) {
                   yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: seq + next, code: CSI_CODE });
                   i += len + 1;
                   setState("SEQUENCE", CSI);
-                } else if (nextCode === OSC_OPEN) {
+                } else if (next === OSC_OPEN_CODE) {
                   yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: seq + next, code: OSC_CODE });
                   i += len + 1;
                   setState("SEQUENCE", OSC);
                 } else if (STRING_OPENERS.has(next)) {
                   yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: seq + next, code: next });
                   i += len + 1;
-                  setState("SEQUENCE", nextCode);
+                  setState("SEQUENCE", next.charCodeAt(0));
                 } else if (next) {
                   let j = i + len;
                   while (j < l && input.charCodeAt(j) >= 0x20 && input.charCodeAt(j) <= 0x2f) j++;

--- a/packages/parser/src/tokenize.escaped.ts
+++ b/packages/parser/src/tokenize.escaped.ts
@@ -96,13 +96,7 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
         if (candidates) {
           for (const [seq, len] of candidates) {
             if (backslashIndex + len > l) continue;
-            let matched = true;
-            for (let k = 0; k < len && matched; k += 2) {
-              matched = input[backslashIndex + k] === seq[k];
-              if (matched && k + 1 < len) {
-                matched = input[backslashIndex + k + 1] === seq[k + 1];
-              }
-            }
+            const matched = input.startsWith(seq, backslashIndex);
             if (matched) {
               isIntroducer = true;
               break;
@@ -128,13 +122,7 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
           let isMatch = false;
           for (const [seq, len] of candidates) {
             if (i + len > l) continue;
-            let isSeqMatch = true;
-            for (let k = 0; k < len && isSeqMatch; k += 2) {
-              isSeqMatch = input[i + k] === seq[k];
-              if (isSeqMatch && k + 1 < len) {
-                isSeqMatch = input[i + k + 1] === seq[k + 1];
-              }
-            }
+            const isSeqMatch = input.startsWith(seq, i);
 
             if (isSeqMatch) {
               isMatch = true;

--- a/packages/parser/src/tokenize.ts
+++ b/packages/parser/src/tokenize.ts
@@ -22,8 +22,6 @@ type State = "GROUND" | "SEQUENCE";
 
 const debug = false;
 
-const INTRODUCERS = new Set([ESC, CSI, OSC, DCS, APC, PM, SOS]);
-
 function emit(token: TOKEN) {
   if (debug) console.log("token", token);
   return token;
@@ -45,7 +43,7 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
       const textStart = i;
       while (i < input.length) {
         const char = input[i];
-        if (INTRODUCERS.has(char)) {
+        if (char === ESC || char === CSI || char === OSC || char === DCS || char === APC || char === PM || char === SOS) {
           break;
         }
         i++;

--- a/packages/parser/src/tokenize.ts
+++ b/packages/parser/src/tokenize.ts
@@ -1,11 +1,16 @@
 import {
   APC,
   BACKSLASH,
+  BACKSLASH_CODE,
   BELL,
+  BELL_CODE,
   C0_INTERRUPTERS,
   CSI,
   CSI_OPEN,
   DCS,
+  CSI_CODE,
+  OSC_CODE,
+  ESC_CODE,
   ESC,
   INTERRUPTERS,
   OSC,
@@ -13,6 +18,7 @@ import {
   PM,
   SOS,
   ST,
+  ST_CODE,
   STRING_OPENERS,
   TOKEN_TYPES,
 } from "./constants.ts";
@@ -30,9 +36,9 @@ function emit(token: TOKEN) {
 export function* tokenizer(input: string): IterableIterator<TOKEN> {
   let i = 0;
   let state: State = "GROUND";
-  let currentCode: string | undefined;
+  let currentCode: number | undefined;
 
-  function setState(next: State, code?: string) {
+  function setState(next: State, code?: number) {
     if (debug) console.log(`state ${state} → ${next}`);
     state = next;
     currentCode = code;
@@ -41,12 +47,16 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
   while (i < input.length) {
     if (state === "GROUND") {
       const textStart = i;
+      let charCode = input.charCodeAt(i);
+      let char = input[i];
+
       while (i < input.length) {
-        const char = input[i];
-        if (char === ESC || char === CSI || char === OSC || char === DCS || char === APC || char === PM || char === SOS) {
+        if (charCode === ESC || charCode === CSI || charCode === OSC || charCode === DCS || charCode === APC || charCode === PM || charCode === SOS) {
           break;
         }
         i++;
+        charCode = input.charCodeAt(i);
+        char = input[i];
       }
 
       if (i > textStart) {
@@ -54,32 +64,32 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
       }
 
       if (i < input.length) {
-        const char = input[i];
-        if (char === CSI || char === OSC || char === DCS || char === APC || char === PM || char === SOS) {
+        if (charCode === CSI || charCode === OSC || charCode === DCS || charCode === APC || charCode === PM || charCode === SOS) {
           yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char, code: char });
           i++;
-          setState("SEQUENCE", char);
-        } else if (char === ESC) {
+          setState("SEQUENCE", charCode);
+        } else if (charCode === ESC) {
           const next = input[i + 1];
-          if (next === CSI_OPEN) {
-            yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char + next, code: CSI });
+          const nextCode = input.charCodeAt(i + 1);
+          if (nextCode === CSI_OPEN) {
+            yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char + next, code: CSI_CODE });
             i += 2;
             setState("SEQUENCE", CSI);
-          } else if (next === OSC_OPEN) {
-            yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char + next, code: OSC });
+          } else if (nextCode === OSC_OPEN) {
+            yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char + next, code: OSC_CODE });
             i += 2;
             setState("SEQUENCE", OSC);
           } else if (STRING_OPENERS.has(next)) {
             yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char + next, code: next });
             i += 2;
-            setState("SEQUENCE", next);
+            setState("SEQUENCE", nextCode);
           } else if (next) {
             let j = i + 1;
             while (j < input.length && input.charCodeAt(j) >= 0x20 && input.charCodeAt(j) <= 0x2f) j++;
             if (j < input.length) {
               const is = input.slice(i + 1, j);
-              if (is) yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char + is, code: ESC, intermediate: is });
-              else yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char, code: ESC });
+              if (is) yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char + is, code: ESC_CODE, intermediate: is });
+              else yield emit({ type: TOKEN_TYPES.INTRODUCER, pos: i, raw: char, code: ESC_CODE });
               i = j;
               setState("SEQUENCE", ESC);
             } else {
@@ -97,14 +107,14 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
 
       if (code === CSI) {
         while (i < input.length) {
+          const charCode = input.charCodeAt(i);
           const char = input[i];
-          if (INTERRUPTERS.has(char)) {
+          if (INTERRUPTERS.has(charCode)) {
             if (data) yield emit({ type: TOKEN_TYPES.DATA, pos, raw: data });
             setState("GROUND");
-            if (C0_INTERRUPTERS.has(char)) i++;
+            if (C0_INTERRUPTERS.has(charCode)) i++;
             break;
           }
-          const charCode = char.charCodeAt(0);
           if (charCode >= 0x40 && charCode <= 0x7e) {
             if (data) yield emit({ type: TOKEN_TYPES.DATA, pos, raw: data });
             yield emit({ type: TOKEN_TYPES.FINAL, pos: i, raw: char });
@@ -117,10 +127,11 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
         }
       } else if (code === ESC) {
         if (i < input.length) {
+          const charCode = input.charCodeAt(i);
           const char = input[i];
-          if (INTERRUPTERS.has(char)) {
+          if (INTERRUPTERS.has(charCode)) {
             setState("GROUND");
-            if (C0_INTERRUPTERS.has(char)) i++;
+            if (C0_INTERRUPTERS.has(charCode)) i++;
           } else {
             yield emit({ type: TOKEN_TYPES.FINAL, pos: i, raw: char });
             i++;
@@ -130,14 +141,15 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
       } else if (code) {
         while (i < input.length) {
           const char = input[i];
+          const charCode = char.charCodeAt(0);
           let terminator: string | undefined;
 
-          if (char === ESC && input[i + 1] === BACKSLASH) {
-            terminator = ESC + BACKSLASH;
-          } else if (char === ST) {
-            terminator = ST;
-          } else if (char === BELL && code === OSC) {
-            terminator = BELL;
+          if (charCode === ESC && input.charCodeAt(i + 1) === BACKSLASH) {
+            terminator = ESC_CODE + BACKSLASH_CODE;
+          } else if (charCode === ST) {
+            terminator = ST_CODE;
+          } else if (charCode === BELL && code === OSC) {
+            terminator = BELL_CODE;
           }
 
           if (terminator) {
@@ -148,10 +160,10 @@ export function* tokenizer(input: string): IterableIterator<TOKEN> {
             break;
           }
 
-          if (INTERRUPTERS.has(char)) {
+          if (INTERRUPTERS.has(charCode)) {
             if (data) yield emit({ type: TOKEN_TYPES.DATA, pos, raw: data });
             setState("GROUND");
-            if (C0_INTERRUPTERS.has(char)) i++;
+            if (C0_INTERRUPTERS.has(charCode)) i++;
             break;
           }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,19 +40,6 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
-  packages/perf:
-    dependencies:
-      kleur:
-        specifier: ^4.1.5
-        version: 4.1.5
-      tinybench:
-        specifier: ^2.9.0
-        version: 2.9.0
-    devDependencies:
-      '@types/node':
-        specifier: ^24.0.13
-        version: 24.0.13
-
 packages:
 
   '@babel/generator@7.28.0':
@@ -613,10 +600,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  kleur@4.1.5:
-    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
-    engines: {node: '>=6'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -698,9 +681,6 @@ packages:
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
-
-  tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
@@ -1223,8 +1203,6 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  kleur@4.1.5: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -1333,8 +1311,6 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-
-  tinybench@2.9.0: {}
 
   tinyexec@1.0.1: {}
 


### PR DESCRIPTION
In all cases I've seen, `Set#has` is much slower than a basic `if` in
this particular case (`INTRODUCERS`). Using an `if` here (which is also
a hot path) speeds up tokenisation significantly.
